### PR TITLE
fix Twig injection

### DIFF
--- a/src/Configuration/DesignConfigPass.php
+++ b/src/Configuration/DesignConfigPass.php
@@ -12,6 +12,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Environment as Twig;
 
 /**
  * Processes the custom CSS styles applied to the backend design based on the
@@ -21,10 +22,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class DesignConfigPass implements ConfigPassInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+
+    private Twig $twig;
     /**
      * @var bool
      */
@@ -39,9 +38,9 @@ class DesignConfigPass implements ConfigPassInterface
      * @var bool
      * @var string
      */
-    public function __construct(ContainerInterface $container, $kernelDebug, $locale)
+    public function __construct(Twig $twig, $kernelDebug, $locale)
     {
-        $this->container = $container;
+        $this->twig = $twig;
         $this->kernelDebug = $kernelDebug;
         $this->locale = $locale;
     }
@@ -70,7 +69,7 @@ class DesignConfigPass implements ConfigPassInterface
 
     private function processCustomCss(array $backendConfig): array
     {
-        $customCssContent = $this->container->get('twig')->render('@EasyAdmin/css/easyadmin.css.twig', [
+        $customCssContent = $this->twig->render('@EasyAdmin/css/easyadmin.css.twig', [
             'brand_color' => $backendConfig['design']['brand_color'],
             'color_scheme' => $backendConfig['design']['color_scheme'],
             'kernel_debug' => $this->kernelDebug,

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -89,7 +89,7 @@
         </service>
 
         <service id="easyadmin.configuration.design_config_pass" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\DesignConfigPass" public="false">
-            <argument id="service_container" type="service" />
+            <argument id="twig" type="service" />
             <argument>%kernel.debug%</argument>
             <argument>%kernel.default_locale%</argument>
             <tag name="easyadmin.config_pass" priority="80" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -23,6 +23,9 @@
             <argument>%easyadmin.config%</argument>
         </service>
 
+        <service id="EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager" alias="easyadmin.config.manager" />
+        <service id="EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder" alias="easyadmin.query_builder" />
+
         <service id="easyadmin.query_builder" class="EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder" public="true">
             <argument type="service" id="doctrine" />
         </service>


### PR DESCRIPTION
The old service definition is not working in Symfony 6, because the Twig service is now private.
